### PR TITLE
Change Deadline class to take in deadline date as LocalDate

### DIFF
--- a/data/saved_tasks.txt
+++ b/data/saved_tasks.txt
@@ -1,4 +1,2 @@
-1, todo, read book
-0, deadline, book report, 15th Sept
-1, event, code meet, 2pm, 4pm
-0, todo, read another book
+0, todo, finish code
+0, deadline, homework, 2024-10-12

--- a/src/main/java/appal/exception/InvalidDeadlineFormatException.java
+++ b/src/main/java/appal/exception/InvalidDeadlineFormatException.java
@@ -1,0 +1,10 @@
+package appal.exception;
+
+public class InvalidDeadlineFormatException extends AppalException {
+    public static final String INVALID_DEADLINE_FORMAT_MESSAGE = "Oh no...I can't parse your deadline input :(" +
+            "\nCheck that the date is in the form yyyy-mm-dd!";
+
+    public InvalidDeadlineFormatException() {
+        super(INVALID_DEADLINE_FORMAT_MESSAGE);
+    }
+}

--- a/src/main/java/appal/exception/UnspecifiedDeadlineException.java
+++ b/src/main/java/appal/exception/UnspecifiedDeadlineException.java
@@ -2,7 +2,7 @@ package appal.exception;
 
 public class UnspecifiedDeadlineException extends AppalException {
     public static final String UNSPECIFIED_DEADLINE_MESSAGE = "Remember to specify a deadline, pal!" +
-            "\nExample input: deadline [TASK] /by [DEADLINE]";
+            "\nExample input: deadline [TASK] /by [DEADLINE FORMAT yyyy-mm-dd]";
 
     public UnspecifiedDeadlineException() {
         super(UNSPECIFIED_DEADLINE_MESSAGE);

--- a/src/main/java/appal/task/Deadline.java
+++ b/src/main/java/appal/task/Deadline.java
@@ -1,17 +1,32 @@
 package appal.task;
 
+import appal.exception.AppalException;
+import appal.exception.InvalidDeadlineFormatException;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
 public class Deadline extends Task {
     protected static final String command = "deadline";
-    protected String by;
+    protected LocalDate by;
 
-    public Deadline(String description, String by) {
+    public Deadline(String description, String by) throws AppalException {
         super(description);
-        this.by = by;
+        try {
+            this.by = LocalDate.parse(by);
+        } catch (DateTimeParseException e) {
+            throw new InvalidDeadlineFormatException();
+        }
+    }
+
+    public String getFormattedDate() {
+        return by.format(DateTimeFormatter.ofPattern("MMM d yyyy"));
     }
 
     @Override
     public String toString() {
-        return "[D]" + super.toString() + "(by: " + by + ")";
+        return "[D]" + super.toString() + "(by: " + getFormattedDate() + ")";
     }
 
     @Override


### PR DESCRIPTION
- To add deadlines, users now have to input the /by argument in the format yyyy-mm-dd
- When creating a deadline object, if the wrong /by argument format is used, a InvalidDeadlineFormatException is thrown